### PR TITLE
Remove "%" sign from the html5 score

### DIFF
--- a/device/dsi/index.html
+++ b/device/dsi/index.html
@@ -10,7 +10,7 @@ browser: Runs an Opera browser
 date: 26/02/2014
 
 score-html5: 89/500
-score-html5-percent: 17.8%
+score-html5-percent: 17.8
 score-html5-date: July 2012
 
 score-css3: Failed to run


### PR DESCRIPTION
Previous version didn't show the percent bar, due to having a % sign after 17.8
